### PR TITLE
Add load_data.ipynb with raw data loading and relative file paths

### DIFF
--- a/notebooks/load_data.ipynb
+++ b/notebooks/load_data.ipynb
@@ -1,0 +1,111 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b2d8283c-2f32-494e-9f76-c26143b0ed40",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "e922d18c-621a-4bb0-ba8b-3ea5be2fd043",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 📂 File paths for raw healthcare data (relative paths from repo root)\n",
+    "train_beneficiary_path = '../data/raw/Train_Beneficiarydata-1542865627584.csv'\n",
+    "train_inpatient_path = '../data/raw/Train_Inpatientdata-1542865627584.csv'\n",
+    "train_outpatient_path = '../data/raw/Train_Outpatientdata-1542865627584.csv'\n",
+    "train_path = '../data/raw/Train-1542865627584.csv'\n",
+    "\n",
+    "test_beneficiary_path = '../data/raw/Test_Beneficiarydata-1542969243754.csv'\n",
+    "test_inpatient_path = '../data/raw/Test_Inpatientdata-1542969243754.csv'\n",
+    "test_outpatient_path = '../data/raw/Test_Outpatientdata-1542969243754.csv'\n",
+    "test_path = '../data/raw/Test-1542969243754.csv'\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "6dbc68db-bc33-4e81-b463-491730426a4b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load training datasets\n",
+    "train_beneficiary = pd.read_csv(train_beneficiary_path)\n",
+    "train_inpatient = pd.read_csv(train_inpatient_path)\n",
+    "train_outpatient = pd.read_csv(train_outpatient_path)\n",
+    "train = pd.read_csv(train_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "85cc6f98-5285-4a1f-8f8d-61ff78589f0a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load test datasets\n",
+    "test_beneficiary = pd.read_csv(test_beneficiary_path)\n",
+    "test_inpatient = pd.read_csv(test_inpatient_path)\n",
+    "test_outpatient = pd.read_csv(test_outpatient_path)\n",
+    "test = pd.read_csv(test_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "04cb70b2-2d2f-493e-9216-2088b4f2907c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Train shape: (5410, 2)\n",
+      "Test shape: (1353, 1)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ✅ View summary\n",
+    "print(\"Train shape:\", train.shape)\n",
+    "print(\"Test shape:\", test.shape)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "758d5de1",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
### Summary

This pull request introduces the first data-loading notebook: `load_data.ipynb`.

### Key Changes
- Added `load_data.ipynb` under `notebooks/` folder.
- Implemented relative paths for raw data in `data/raw/`.
- Successfully loaded all training and test datasets using `pandas.read_csv()`.

### Notes
- All `.csv` files are organized in `data/raw/` to support consistent repository structure.
- Notebook has been saved and executed successfully without errors.

---

✔ Ready for review and merge into `main`.
