### PR TITLE
Add cleaning logic for beneficiary dataset to clean_data.ipynb

### DIFF
--- a/notebooks/clean_data.ipynb
+++ b/notebooks/clean_data.ipynb
@@ -5,26 +5,228 @@
    "execution_count": 1,
    "id": "757b66bd",
    "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "6446466d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 📂 File paths for raw healthcare data (relative paths from repo root)\n",
+    "train_beneficiary_path = '../data/raw/Train_Beneficiarydata-1542865627584.csv'\n",
+    "train_inpatient_path = '../data/raw/Train_Inpatientdata-1542865627584.csv'\n",
+    "train_outpatient_path = '../data/raw/Train_Outpatientdata-1542865627584.csv'\n",
+    "train_path = '../data/raw/Train-1542865627584.csv'\n",
+    "\n",
+    "test_beneficiary_path = '../data/raw/Test_Beneficiarydata-1542969243754.csv'\n",
+    "test_inpatient_path = '../data/raw/Test_Inpatientdata-1542969243754.csv'\n",
+    "test_outpatient_path = '../data/raw/Test_Outpatientdata-1542969243754.csv'\n",
+    "test_path = '../data/raw/Test-1542969243754.csv'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "7691d28a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load training datasets\n",
+    "train_beneficiary = pd.read_csv(train_beneficiary_path)\n",
+    "train_inpatient = pd.read_csv(train_inpatient_path)\n",
+    "train_outpatient = pd.read_csv(train_outpatient_path)\n",
+    "train = pd.read_csv(train_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "aec79140",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load test datasets\n",
+    "test_beneficiary = pd.read_csv(test_beneficiary_path)\n",
+    "test_inpatient = pd.read_csv(test_inpatient_path)\n",
+    "test_outpatient = pd.read_csv(test_outpatient_path)\n",
+    "test = pd.read_csv(test_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "803dad69",
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "This notebook will clean the healthcare data.\n"
+      "Train shape: (5410, 2)\n",
+      "Test shape: (1353, 1)\n"
      ]
     }
    ],
    "source": [
-    "import pandas as pd\n",
+    "# ✅ View summary\n",
+    "print(\"Train shape:\", train.shape)\n",
+    "print(\"Test shape:\", test.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "af561a78",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Initial structure of train_beneficiary:\n",
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "RangeIndex: 138556 entries, 0 to 138555\n",
+      "Data columns (total 25 columns):\n",
+      " #   Column                           Non-Null Count   Dtype \n",
+      "---  ------                           --------------   ----- \n",
+      " 0   BeneID                           138556 non-null  object\n",
+      " 1   DOB                              138556 non-null  object\n",
+      " 2   DOD                              1421 non-null    object\n",
+      " 3   Gender                           138556 non-null  int64 \n",
+      " 4   Race                             138556 non-null  int64 \n",
+      " 5   RenalDiseaseIndicator            138556 non-null  object\n",
+      " 6   State                            138556 non-null  int64 \n",
+      " 7   County                           138556 non-null  int64 \n",
+      " 8   NoOfMonths_PartACov              138556 non-null  int64 \n",
+      " 9   NoOfMonths_PartBCov              138556 non-null  int64 \n",
+      " 10  ChronicCond_Alzheimer            138556 non-null  int64 \n",
+      " 11  ChronicCond_Heartfailure         138556 non-null  int64 \n",
+      " 12  ChronicCond_KidneyDisease        138556 non-null  int64 \n",
+      " 13  ChronicCond_Cancer               138556 non-null  int64 \n",
+      " 14  ChronicCond_ObstrPulmonary       138556 non-null  int64 \n",
+      " 15  ChronicCond_Depression           138556 non-null  int64 \n",
+      " 16  ChronicCond_Diabetes             138556 non-null  int64 \n",
+      " 17  ChronicCond_IschemicHeart        138556 non-null  int64 \n",
+      " 18  ChronicCond_Osteoporasis         138556 non-null  int64 \n",
+      " 19  ChronicCond_rheumatoidarthritis  138556 non-null  int64 \n",
+      " 20  ChronicCond_stroke               138556 non-null  int64 \n",
+      " 21  IPAnnualReimbursementAmt         138556 non-null  int64 \n",
+      " 22  IPAnnualDeductibleAmt            138556 non-null  int64 \n",
+      " 23  OPAnnualReimbursementAmt         138556 non-null  int64 \n",
+      " 24  OPAnnualDeductibleAmt            138556 non-null  int64 \n",
+      "dtypes: int64(21), object(4)\n",
+      "memory usage: 26.4+ MB\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Initial structure of train_beneficiary:\")\n",
+    "train_beneficiary.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "07380a89",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# CLEANING + FEATURE ENGINEERING\n",
+    "def data_cleaning_beneficiary(df):\n",
+    "    df['DOB'] = pd.to_datetime(df['DOB'], errors='coerce')\n",
+    "    df['DOD'] = pd.to_datetime(df['DOD'], errors='coerce')\n",
+    "    \n",
+    "    numerical_cols = df.select_dtypes(include=['float64', 'int64']).columns\n",
+    "    df[numerical_cols] = df[numerical_cols].fillna(df[numerical_cols].median())\n",
     "\n",
-    "# Placeholder for cleaning script\n",
-    "print(\"This notebook will clean the healthcare data.\")\n"
+    "    categorical_cols = df.select_dtypes(include=['object']).columns\n",
+    "    df[categorical_cols] = df[categorical_cols].fillna(df[categorical_cols].mode().iloc[0])\n",
+    "\n",
+    "    category_columns = ['Gender', 'Race', 'RenalDiseaseIndicator', 'State', 'County']\n",
+    "    for col in category_columns:\n",
+    "        if col in df.columns:\n",
+    "            df[col] = df[col].astype('category')\n",
+    "\n",
+    "    return df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "4eff5d04",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def add_engineered_features(df):\n",
+    "    df['AgeAtDeathOrLastClaim'] = ((df['DOD'].fillna(pd.Timestamp('2020-01-01')) - df['DOB']).dt.days // 365)\n",
+    "    return df\n",
+    "\n",
+    "# APPLY LOGIC\n",
+    "train_beneficiary = add_engineered_features(data_cleaning_beneficiary(train_beneficiary))\n",
+    "test_beneficiary = add_engineered_features(data_cleaning_beneficiary(test_beneficiary))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "ce3753f9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Post-cleaning structure of train_beneficiary:\n",
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "RangeIndex: 138556 entries, 0 to 138555\n",
+      "Data columns (total 26 columns):\n",
+      " #   Column                           Non-Null Count   Dtype         \n",
+      "---  ------                           --------------   -----         \n",
+      " 0   BeneID                           138556 non-null  object        \n",
+      " 1   DOB                              138556 non-null  datetime64[ns]\n",
+      " 2   DOD                              1421 non-null    datetime64[ns]\n",
+      " 3   Gender                           138556 non-null  category      \n",
+      " 4   Race                             138556 non-null  category      \n",
+      " 5   RenalDiseaseIndicator            138556 non-null  category      \n",
+      " 6   State                            138556 non-null  category      \n",
+      " 7   County                           138556 non-null  category      \n",
+      " 8   NoOfMonths_PartACov              138556 non-null  int64         \n",
+      " 9   NoOfMonths_PartBCov              138556 non-null  int64         \n",
+      " 10  ChronicCond_Alzheimer            138556 non-null  int64         \n",
+      " 11  ChronicCond_Heartfailure         138556 non-null  int64         \n",
+      " 12  ChronicCond_KidneyDisease        138556 non-null  int64         \n",
+      " 13  ChronicCond_Cancer               138556 non-null  int64         \n",
+      " 14  ChronicCond_ObstrPulmonary       138556 non-null  int64         \n",
+      " 15  ChronicCond_Depression           138556 non-null  int64         \n",
+      " 16  ChronicCond_Diabetes             138556 non-null  int64         \n",
+      " 17  ChronicCond_IschemicHeart        138556 non-null  int64         \n",
+      " 18  ChronicCond_Osteoporasis         138556 non-null  int64         \n",
+      " 19  ChronicCond_rheumatoidarthritis  138556 non-null  int64         \n",
+      " 20  ChronicCond_stroke               138556 non-null  int64         \n",
+      " 21  IPAnnualReimbursementAmt         138556 non-null  int64         \n",
+      " 22  IPAnnualDeductibleAmt            138556 non-null  int64         \n",
+      " 23  OPAnnualReimbursementAmt         138556 non-null  int64         \n",
+      " 24  OPAnnualDeductibleAmt            138556 non-null  int64         \n",
+      " 25  AgeAtDeathOrLastClaim            138556 non-null  int64         \n",
+      "dtypes: category(5), datetime64[ns](2), int64(18), object(1)\n",
+      "memory usage: 23.0+ MB\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Post-cleaning structure of train_beneficiary:\")\n",
+    "train_beneficiary.info()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6446466d",
+   "id": "e55912ec",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/notebooks/clean_data.ipynb
+++ b/notebooks/clean_data.ipynb
@@ -1,0 +1,54 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "757b66bd",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "This notebook will clean the healthcare data.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "# Placeholder for cleaning script\n",
+    "print(\"This notebook will clean the healthcare data.\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6446466d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR adds beneficiary cleaning logic to clean_data.ipynb:

✅ Converted DOB/DOD to datetime  
✅ Imputed missing numeric and categorical values  
✅ Converted demographic fields to category  
✅ Engineered AgeAtDeathOrLastClaim feature  

Notebook tested and executed successfully.